### PR TITLE
IE 9 and CORS

### DIFF
--- a/src/app/api/queryController.js
+++ b/src/app/api/queryController.js
@@ -32,7 +32,8 @@
       
       es.getLastAssets(options, function (err, entries) {
         var commits = gitHubEventsToApiResponse(entries);
-        res.jsonp(commits);
+        res.set("Content-Type", "application/json");
+        res.send(commits);
       });
     });
   };

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -6,7 +6,7 @@ var express = require('express'),
     exphbs = require('express-handlebars');
 
 app.get('/version', function(req, res) {
-    res.jsonp({version:"0.0.0"});
+    res.json({version:"0.0.0"});
 });
 
 var api = require("./api");

--- a/src/app/views/app.handlebars
+++ b/src/app/views/app.handlebars
@@ -38,12 +38,7 @@
                 data.resourcePath = "{{{resourcePath}}}";
 
                 if (assetDetailCommitsTmpl === null) {
-                    $.ajax({
-                      url: '{{{templateUrl}}}',
-                      dataType: 'html'
-                    })
-                    //$.get('{{{templateUrl}}}&callback=?')
-                    .done(function(source) {
+                    $.get('{{{templateUrl}}}').done(function(source) {
                         try {
                             assetDetailCommitsTmpl = handlebars.compile(source);
                             render(commitStreamDomId, data, errorHandler);

--- a/src/app/views/app.handlebars
+++ b/src/app/views/app.handlebars
@@ -30,7 +30,7 @@
     }
 
     function queryCommitStream(commitStreamDomId, workitem, handlebars, errorHandler) {
-        $.getJSON('{{{apiUrl}}}' + workitem + '&callback=?').done(function(data) {
+        $.getJSON('{{{apiUrl}}}' + workitem).done(function(data) {
             if (!data || !data.commits) {
                 errorHandler();
             } else {


### PR DESCRIPTION
These changes were not necessary as the use of the jQuery.XDomainRequest.js
plugin helps us out here, and we do not need to set up a CORS proxy as we 
thought we might have to do.

D-08830
