### PR TITLE
Use repository remoteUrl to build navigable/HTML commit url

### DIFF
--- a/src/app/api/translators/es6/vsoGitTranslator.js
+++ b/src/app/api/translators/es6/vsoGitTranslator.js
@@ -22,8 +22,8 @@ const vsoGitTranslator = {
       const getHtmlCommitUrl = theCommit => {
         const repositoryName = encodeURIComponent(pushEvent.resource.repository.name);
         // Original format: https://v1platformtest.visualstudio.com/DefaultCollection/_apis/git/repositories/d29767bb-8f5f-4c43-872f-6c73635a1256/commits/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
-        // Expected format: https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1%20Integration/commit/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
-        const url = theCommit.url.replace(/_apis\/git\/repositories\/.*?\/commits\//i, `_git/${repositoryName}/commit/`);
+        // Expected format: https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1 Integration/commit/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
+        const url = pushEvent.resource.repository.remoteUrl + '/commit/' + theCommit.commitId;
         return url;
       };
 

--- a/src/app/api/translators/vsoGitTranslator.js
+++ b/src/app/api/translators/vsoGitTranslator.js
@@ -44,8 +44,8 @@ var vsoGitTranslator = {
         var getHtmlCommitUrl = function getHtmlCommitUrl(theCommit) {
           var repositoryName = encodeURIComponent(pushEvent.resource.repository.name);
           // Original format: https://v1platformtest.visualstudio.com/DefaultCollection/_apis/git/repositories/d29767bb-8f5f-4c43-872f-6c73635a1256/commits/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
-          // Expected format: https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1%20Integration/commit/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
-          var url = theCommit.url.replace(/_apis\/git\/repositories\/.*?\/commits\//i, '_git/' + repositoryName + '/commit/');
+          // Expected format: https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1 Integration/commit/e771d9b9d5abab2da4107a0e6db05cef21e40ce8
+          var url = pushEvent.resource.repository.remoteUrl + '/commit/' + theCommit.commitId;
           return url;
         };
 

--- a/src/app/test/api/translators/vsoGitTranslator.tests.js
+++ b/src/app/test/api/translators/vsoGitTranslator.tests.js
@@ -150,7 +150,7 @@ describe('vsoGitTranslator', function() {
                     },
                     "message": "changed code"
                 },
-                "html_url": "https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1%20Integration/commit/cf383dd370a74a8a5062385f6c1723fcc7cc66eb",
+                "html_url": "https://v1platformtest.visualstudio.com/DefaultCollection/_git/V1 Integration/commit/cf383dd370a74a8a5062385f6c1723fcc7cc66eb",
                 "repository": {
                     "id": "d29767bb-8f5f-4c43-872f-6c73635a1256",
                     "name": "V1 Integration"
@@ -183,6 +183,8 @@ describe('vsoGitTranslator', function() {
             var actual = vsoGitTranslator.translatePush(pushEventWithOneCommit, '111', '222', '333');
             actual.should.deep.equal(expected);
         });
+
+
     });
 
     describe('when translating a malformed push event', function() {


### PR DESCRIPTION
The side-effect of this change is that the "html_url" property of a translated commit is no longer encoded (since the repository remote url I use as a base is not).
