### PR TITLE
S-60961 Change the regex to no longer care about the . for the .com

### DIFF
--- a/src/app/api/translators/es6/vsoGitTranslator.js
+++ b/src/app/api/translators/es6/vsoGitTranslator.js
@@ -73,7 +73,7 @@ const vsoGitTranslator = {
       repoHref: ''
     };
 
-    const urlComponents = html_url.match(/http.?:\/\/(.*?)\..*?_git\/(.*?)\/commit/);
+    const urlComponents = html_url.match(/http.?:\/\/..*?_git\/(.*?)\/commit/);
     const serverUrlMatch = html_url.match(/(http.?:)\/\/(.*?_git)\//);
 
     if (urlComponents !== null && serverUrlMatch !== null) {

--- a/src/app/api/translators/vsoGitTranslator.js
+++ b/src/app/api/translators/vsoGitTranslator.js
@@ -100,7 +100,7 @@ var vsoGitTranslator = {
       repoHref: ''
     };
 
-    var urlComponents = html_url.match(/http.?:\/\/(.*?)\..*?_git\/(.*?)\/commit/);
+    var urlComponents = html_url.match(/http.?:\/\/..*?_git\/(.*?)\/commit/);
     var serverUrlMatch = html_url.match(/(http.?:)\/\/(.*?_git)\//);
 
     if (urlComponents !== null && serverUrlMatch !== null) {


### PR DESCRIPTION
On premise url will more likely look like {https://host:port} rather than
{https://host.com}. So this change will work in either case