### PR TITLE
D-12350 Manually escape unsafe content with handlebars

### DIFF
--- a/src/app/client/commitsList.html
+++ b/src/app/client/commitsList.html
@@ -42,7 +42,7 @@
                 {{/if}}
             </div>
    	</div>
-    <p class="csMessage commit.message"><span class="message">{{message}}</span></p>
+    <p class="csMessage commit.message"><span class="message">{{{message}}}</span></p>
   </li>
   {{/each}}
 </ol>

--- a/src/app/views/app.handlebars
+++ b/src/app/views/app.handlebars
@@ -15,10 +15,19 @@
     showChildrenChecked,
     assetNumbers,
     mentionUrl,
+    handlebars,
     validator;
 
   var clone = function(source) {
     return JSON.parse(JSON.stringify(source));
+  };
+
+  var escapeUnsafeContent = function(model) {
+    for (var i = 0; i < model.commits.length; i++) {
+      var commit = model.commits[i];
+      var processedMessage = handlebars.default.Utils.escapeExpression(commit.message);
+      commit.message = processedMessage;
+    }
   };
 
   var commitsListModelPreprocessorPlugins = [
@@ -108,6 +117,7 @@
           registerPartial('commitsList', tmpl, function() {
             getCompiledTemplate('commitsContainer.html', function(tmpl) {
               commitsContainerTmpl = tmpl;
+              escapeUnsafeContent(modelCopy);
               processCommitsListPreprocessorPlugins(modelCopy);
               setStreamContent(modelCopy);
               checkIfNextPage(model);
@@ -117,6 +127,7 @@
           });
         });
       } else {
+        escapeUnsafeContent(modelCopy);
         processCommitsListPreprocessorPlugins(modelCopy);
         setStreamContent(modelCopy);
         checkIfNextPage(model);
@@ -135,12 +146,14 @@
       if (!commitsListTmpl) {
         getCompiledTemplate('commitsList.html', function(tmpl) {
           commitsListTmpl = tmpl;
+          escapeUnsafeContent(modelCopy);
           processCommitsListPreprocessorPlugins(modelCopy);
           var content = tmpl(modelCopy);
           $(commitStreamDomId).find('.side-panel-scrollable').append(content);
           checkIfNextPage(model);            
         });
       } else {
+        escapeUnsafeContent(modelCopy);
         processCommitsListPreprocessorPlugins(modelCopy);
         var content = commitsListTmpl(modelCopy);
         $(commitStreamDomId).find('.side-panel-scrollable').append(content);
@@ -152,9 +165,10 @@
   };
 
   var compileSource = function(source, cb) {
-    require(deps, function(handlebars, validatorDep) {
+    require(deps, function(handlebarsDep, validatorDep) {
+      handlebars = handlebarsDep;
       validator = validatorDep;
-      cb(handlebars.default.compile(source));
+      cb(handlebarsDep.default.compile(source));
     }, errorHandler);
   };
 


### PR DESCRIPTION
We have code that auto-links asset mentions to assetdetail.v1, so we need to
allow the template to pass actual tags via the {{{message}}} syntax. So,
to ensure that the commit message content itself still gets escaped, we
pass it manually to handlebars.default.Utils.escapeExpression.