### PR TITLE
Show sub-family icons

### DIFF
--- a/src/app/client/partials/commitStreamAdmin.html
+++ b/src/app/client/partials/commitStreamAdmin.html
@@ -548,7 +548,11 @@ div.vcs-subfamily-options input[type="radio"] {
           <th>Repository Name</th>
         </tr>
         <tr ng-repeat-start='inbox in inboxes'>
-          <td class='inbox-link'><img ng-src='{{familyIcon(inbox.family)}}' style="height:32px" />&nbsp;<a target='_blank' href='{{inbox.url}}'>{{inbox.name}}</a></td>
+          <td class='inbox-link'>
+            <img ng-src='{{familyIcon(inbox.family)}}' style="height:32px" />
+            <img ng-if='isSubFamily(inbox.family)' ng-src='{{getSubFamilyIcon(null, inbox.family)}}' style="height:16px; width:16px; " />&nbsp;
+            <a target='_blank' href='{{inbox.url}}'>{{inbox.name}}</a>
+          </td>
         </tr>
         <tr ng-repeat-end ng-init='adjustOverlay()'></tr>
       </table>


### PR DESCRIPTION
Issue: When listing the global repositories in read-only mode
(for example: Global option in TeamRoom CommitStream settings UI), the
sub-family icons are not shown. This is inconsistent with the screens
where the list can be edited (for example, Custom option in TeamRoom
CommitStream settings UI).

Solution: Show sub-family icons in all screens (where the repository is a sub-family).