### PR TITLE
D-14278 Promise cleanup for tfsGitResponder

### DIFF
--- a/src/app/api/inboxes/commitsCreate.js
+++ b/src/app/api/inboxes/commitsCreate.js
@@ -57,16 +57,11 @@ exports['default'] = function (req, res) {
         });
     } else {
         var responder = _respondersResponderFactory2['default'].create(req);
-        return responder.respond(res);
-
-        /*
-        const responder = responderFactory.create(req);
         if (responder) {
             return responder.respond(res);
+        } else {
+            throw new _middlewareMalformedPushEventError2['default'](req);
         }
-        else {
-            throw new MalformedPushEventError(req);
-        }*/
     }
 };
 

--- a/src/app/api/inboxes/es6/commitsCreate.js
+++ b/src/app/api/inboxes/es6/commitsCreate.js
@@ -35,15 +35,11 @@ export default (req, res) => {
     } 
     else {
         const responder = responderFactory.create(req);
-        return responder.respond(res);
-
-        /*
-        const responder = responderFactory.create(req);
         if (responder) {
             return responder.respond(res);
         }
         else {
             throw new MalformedPushEventError(req);
-        }*/
+        }
     }
 };

--- a/src/app/api/responders/es6/tfsGitResponder.js
+++ b/src/app/api/responders/es6/tfsGitResponder.js
@@ -15,13 +15,13 @@ const tfsGitResponder = {
 
     respond(res) {
         return new Promise((resolve, reject) => {
-            res.status(202).send('The CommitStream accepted your push but no action will be taken since it is likely a push after a merge ')
-            .done(() => {
-                resolve(res);
-            })
-            .fail(() => {
-                reject(null);
-            });
+            try {
+                res.status(202).json({message:'The CommitStream accepted your push but no action will be taken since it is likely a push after a merge '});
+                resolve();
+            }
+            catch (err) {
+                reject(err);
+            }
         });
     }
 }

--- a/src/app/api/responders/tfsGitResponder.js
+++ b/src/app/api/responders/tfsGitResponder.js
@@ -27,11 +27,12 @@ var tfsGitResponder = {
 
     respond: function respond(res) {
         return new _Promise(function (resolve, reject) {
-            res.status(202).send('The CommitStream accepted your push but no action will be taken since it is likely a push after a merge ').done(function () {
-                resolve(res);
-            }).fail(function () {
-                reject(null);
-            });
+            try {
+                res.status(202).json({ message: 'The CommitStream accepted your push but no action will be taken since it is likely a push after a merge ' });
+                resolve();
+            } catch (err) {
+                reject(err);
+            }
         });
     }
 };


### PR DESCRIPTION
With these changes, things seem to be working well. I stuffed a "throw 'BS Error';" into the catch block of the responder to see that it was flowing through into reject properly and it seemed to invoke the proper trapping behavior to return the "Unexpected error" message to the browser.

(That is, the .done and .fail are jQuery Deferred syntax, and we didn't need to chain into the res calls, just needed to wrap a try around them to ensure that if we catch any exception from them we can flow it throw `reject`.)

All unit tests pass.

All of the CommitStream.Web.Tests are passing properly. We can add a new one tomorrow to the responder to round those out. 