### PR TITLE
D-16108_remove_xdomain

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -144,17 +144,17 @@ Teams in VersionOne can have their own collections of repositories. When you con
 
 The API domain term for groups of repositories is `digest`. You can fetch the list of all the `digest` objects that your CommitStream instance contains by fetching the `/digests` route
 
-* The structure of the URL is: `https://commitstream.v1host.com/api/`**instanceId**`/digests&apiKey=`**apiKey**
+* The structure of the URL is: `https://commitstream.v1host.com/api/`**instanceId**`/digests?apiKey=`**apiKey**
 * Exmaple to query for digests within an instance:
 
-> https://commitstream.v1host.com/api/48bf06cb-9b84-4700-9325-2df87b93e227/digests&apiKey=db479bc8-bb3b-48de-ac05-fd5c8c0a089f
+> https://commitstream.v1host.com/api/48bf06cb-9b84-4700-9325-2df87b93e227/digests?apiKey=db479bc8-bb3b-48de-ac05-fd5c8c0a089f
 
 ## Sample Query for Digests within an Instance
 
 As just mentioned, you first need to know the address for the `digest` you wanto query. The following request fetches **all** the digests within my sample instance. Just plugin the values for your own `instanceId` and `apiKey` to get the list for your own CommitStream instance:
 
 ```bash
-$ curl https://commitstream.v1host.com/api/48bf06cb-9b84-4700-9325-2df87b93e227/digests&apiKey=db479bc8-bb3b-48de-ac05-fd5c8c0a089f | python -mjson.tool
+$ curl https://commitstream.v1host.com/api/48bf06cb-9b84-4700-9325-2df87b93e227/digests?apiKey=db479bc8-bb3b-48de-ac05-fd5c8c0a089f | python -mjson.tool
 ```
 
 ### Response

--- a/src/app/client/bower.json
+++ b/src/app/client/bower.json
@@ -23,8 +23,7 @@
     "bootstrap": "3.3.4",
     "bootstrap-toggle": "2.2.0",
     "angular-hal": "git://github.com/openAgile/angular-hal.git#c9ddf6789e",
-    "angular-prompt": "1.1.1",
-    "xdomain": "0.7.3"
+    "angular-prompt": "1.1.1"
   },
   "resolutions": {
     "angular": "1.4.4",

--- a/src/app/client/js/adminBootstrap.js
+++ b/src/app/client/js/adminBootstrap.js
@@ -67,15 +67,6 @@
     console.error(exception);
   };
 
-  var prependXdomain = function prependXdomain(commitStreamRoot) {
-    setTimeout(function () {
-      if (window.xdomain) {
-        return;
-      }
-      commitStreamRoot.prepend($('<scr' + ('ipt src="' + serviceUrl + '/bower_components/xdomain/dist/xdomain.min.js" slave="' + serviceUrl + '/proxy.html"></scr') + 'ipt>"'));
-    }, 1000);
-  };
-
   try {
     (function () {
       var scriptEl = $($('script[data-commitstream-root]')[0]);
@@ -96,9 +87,6 @@
       // TODO: enable after new styles are released in V1 Prod
       prependStyleSheet(commitStreamRoot, serviceUrl + '/css/bootstrap-toggle.min.css');
       prependStyleSheet(commitStreamRoot, serviceUrl + '/css/glyphicon.css');
-
-      // XDomain support for IE9 especially
-      prependXdomain(commitStreamRoot);
 
       //only load angular and friends once
       if (window.CommitStreamAdminBoot) {

--- a/src/app/client/js/es6/adminBootstrap.js
+++ b/src/app/client/js/es6/adminBootstrap.js
@@ -67,17 +67,6 @@
     console.error(exception);
   };
 
-  let prependXdomain = commitStreamRoot => {
-    setTimeout(function() {
-      if (window.xdomain) {
-        return;
-      }
-      commitStreamRoot.prepend(
-        $('<scr' + `ipt src="${serviceUrl}/bower_components/xdomain/dist/xdomain.min.js" slave="${serviceUrl}/proxy.html"></scr` + 'ipt>"')
-      );
-    }, 1000);
-  };
-
   try {
     let scriptEl = $($('script[data-commitstream-root]')[0]);
 
@@ -111,9 +100,6 @@
     // TODO: enable after new styles are released in V1 Prod
     prependStyleSheet(commitStreamRoot, serviceUrl + '/css/bootstrap-toggle.min.css');
     prependStyleSheet(commitStreamRoot, serviceUrl + '/css/glyphicon.css');
-
-    // XDomain support for IE9 especially
-    prependXdomain(commitStreamRoot);
 
     //only load angular and friends once
     if (window.CommitStreamAdminBoot) {

--- a/src/app/client/proxy.html
+++ b/src/app/client/proxy.html
@@ -1,3 +1,0 @@
-
-<!DOCTYPE HTML>
-<script src="/bower_components/xdomain/dist/xdomain.min.js" master="*"></script>


### PR DESCRIPTION
From Developing to staging

We don't need IE 9 support any more, and that is the only
reason we had this in the code. It was causing render issues
with the AJAXed in content of menus and the user preferences dialog
inside of Core. Note: after merging and deploying the updates build to CS production, we need to use the Kudu console to manually run bower prune from the src/app/client folder to remove the xdomain folder.