### PR TITLE
Call errorHandler() if commit query fails #252

### DIFF
--- a/src/app/views/app.handlebars
+++ b/src/app/views/app.handlebars
@@ -311,8 +311,7 @@
     $('.overlay').show();    
     $.getJSON(apiUrl).done(function(model) {
       cb(model);        
-      }).fail(function(errorHandler) {        
-    });
+      }).fail(errorHandler);
   };
 
   var queryCallback = function(model) {

--- a/src/app/views/app2.handlebars
+++ b/src/app/views/app2.handlebars
@@ -314,8 +314,7 @@
     $('.overlay').show();    
     $.getJSON(apiUrl).done(function(model) {
       cb(model);        
-      }).fail(function(errorHandler) {        
-    });
+      }).fail(errorHandler);
   };
 
   var queryCallback = function(model) {


### PR DESCRIPTION
It is likely an omission that the errorHandler is not
called if there is failure querying for commit data.